### PR TITLE
Moved shebang correct place in tcpTelescope.py

### DIFF
--- a/tcpTelescope.py
+++ b/tcpTelescope.py
@@ -1,11 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 #An adaption of a TCPTelescope, piping to arduino
 
 #Thank you to Sven Steinbauer (https://github.com/Svenito) for the basis of this code
 
 #Arduino communications added by Keegan Crankshaw (http://github.com/KCrankshaw)
 
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import struct, time, socket, select, serial, ephem
 from math import *
 


### PR DESCRIPTION
shebangs only work if they're the first line in the file
